### PR TITLE
Format json timestamps without time offset

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -20,6 +20,8 @@ configure do
   end
 end
 
+TIMESTAMP_FORMAT="%Y-%m-%dT%H:%M:%S"
+
 def create_json_response(metric, id)
 {
     :response_info => {:status => "ok"},
@@ -29,7 +31,7 @@ def create_json_response(metric, id)
       :source => ["Google Analytics", "Celebrus", "Omniture"],
       :data => WeeklyReach::Model.last_six_months_data(metric)
     },
-    :updated_at => WeeklyReach::Model.updated_at(metric)
+    :updated_at => WeeklyReach::Model.updated_at(metric).strftime(TIMESTAMP_FORMAT)
   }.to_json
 end
 

--- a/spec/integration/weekly_reach_spec.rb
+++ b/spec/integration/weekly_reach_spec.rb
@@ -36,6 +36,7 @@ describe "weekly-visitors" do
     response.should have_key(:id)
     response.should have_key(:web_url)
     response.should have_key(:updated_at)
+    response[:updated_at].should =~ /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/
     response[:response_info][:status].should == "ok"
 
     data = response[:details][:data]


### PR DESCRIPTION
This reflects what is actually being returned because of DataMapper
killing time offsets.
The time offsets will come back when the DataMapper patch goes in and
the data is migrated.
