### PR TITLE
Integrate daylight saving support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 source 'https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/'
 
 gem "rake"
-gem "datainsight_recorder", "0.3.1"
+gem "datainsight_recorder", "0.4.1"
 gem "datainsight_logging", "0.0.3"
 gem "airbrake", "3.1.5"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,11 +5,11 @@ GEM
     activesupport (3.2.8)
       i18n (~> 0.6)
       multi_json (~> 1.0)
-    addressable (2.2.8)
+    addressable (2.3.5)
     airbrake (3.1.5)
       builder
       girl_friday
-    bcrypt-ruby (3.0.1)
+    bcrypt-ruby (3.1.2)
     builder (3.0.0)
     bunny (0.8.0)
     ci_reporter (1.7.1)
@@ -25,22 +25,23 @@ GEM
       dm-transactions (~> 1.2.0)
       dm-types (~> 1.2.0)
       dm-validations (~> 1.2.0)
-    data_objects (0.10.12)
+    data_objects (0.10.13)
       addressable (~> 2.1)
     datainsight_logging (0.0.3)
       logging
-    datainsight_recorder (0.3.1)
+    datainsight_recorder (0.4.1)
       bunny
       data_mapper (= 1.2.0)
       datainsight_logging
       dm-mysql-adapter (= 1.2.0)
+      tzinfo (~> 0.3.37)
     diff-lcs (1.1.3)
     dm-aggregates (1.2.0)
       dm-core (~> 1.2.0)
     dm-constraints (1.2.0)
       dm-core (~> 1.2.0)
-    dm-core (1.2.0)
-      addressable (~> 2.2.6)
+    dm-core (1.2.1)
+      addressable (~> 2.3)
     dm-do-adapter (1.2.0)
       data_objects (~> 0.10.6)
       dm-core (~> 1.2.0)
@@ -69,8 +70,8 @@ GEM
       uuidtools (~> 2.1)
     dm-validations (1.2.0)
       dm-core (~> 1.2.0)
-    do_mysql (0.10.12)
-      data_objects (= 0.10.12)
+    do_mysql (0.10.13)
+      data_objects (= 0.10.13)
     factory_girl (4.0.0)
       activesupport (>= 3.0.0)
     fastercsv (1.5.5)
@@ -79,8 +80,8 @@ GEM
       rubinius-actor
     gli (1.6.0)
     i18n (0.6.0)
-    json (1.7.7)
-    json_pure (1.7.7)
+    json (1.8.1)
+    json_pure (1.8.1)
     kgio (2.7.4)
     little-plugger (1.1.3)
     logging (1.8.1)
@@ -112,11 +113,12 @@ GEM
     stringex (1.5.1)
     tilt (1.3.3)
     timecop (0.4.5)
+    tzinfo (0.3.38)
     unicorn (4.3.1)
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
-    uuidtools (2.1.3)
+    uuidtools (2.1.4)
 
 PLATFORMS
   ruby
@@ -126,7 +128,7 @@ DEPENDENCIES
   bunny
   ci_reporter
   datainsight_logging (= 0.0.3)
-  datainsight_recorder (= 0.3.1)
+  datainsight_recorder (= 0.4.1)
   factory_girl
   gli (= 1.6.0)
   rack-test

--- a/lib/model.rb
+++ b/lib/model.rb
@@ -36,6 +36,16 @@ module WeeklyReach
       record.source = message[:envelope][:collector]
       record.value = message[:payload][:value][metric]
       record.save
+      begin
+        record.save
+      rescue DataMapper::SaveFailureError => e
+        begin
+          logger.error("SaveFailure: #{e.resource.errors.inspect}")
+        rescue NoMethodError
+          logger.error("SaveFailure (no detail): #{e}")
+        end
+        raise
+      end
     end
 
     def self.last_18_months_data(metric)

--- a/spec/integration/spec_helper.rb
+++ b/spec/integration/spec_helper.rb
@@ -2,14 +2,25 @@ require_relative "../spec_helper"
 
 require 'sinatra/base'
 require "rack/test"
+require "tzinfo"
 
 require_relative "../../lib/app"
+
+def localise(date_time)
+  # Convert a DateTime to the same time but in the Europe/London timezone
+  # ie. 2012-08-08T00:00:00+00:00 -> 2012-08-08T00:00:00+01:00
+  tz = TZInfo::Timezone.get("Europe/London")
+  if tz.period_for_utc(date_time).utc_total_offset_rational > 0
+    date_time = date_time.new_offset(tz.period_for_utc(date_time).utc_total_offset_rational) - Rational(1, 24)
+  end
+  date_time
+end
 
 def create_measurements(start_at, end_at, params={})
   while start_at < end_at
     each_end_at = start_at + 7
-    params[:start_at] = start_at
-    params[:end_at] = each_end_at
+    params[:start_at] = localise(start_at)
+    params[:end_at] = localise(each_end_at)
     FactoryGirl.create(:model, params)
 
     start_at += 7

--- a/spec/recorders/weekly_visits_recorder_spec.rb
+++ b/spec/recorders/weekly_visits_recorder_spec.rb
@@ -11,8 +11,8 @@ describe "WeeklyVisitsRecorder" do
             :_routing_key => "google_analytics.visits.weekly"
         },
         :payload => {
-            :start_at => "2011-03-28T00:00:00",
-            :end_at => "2011-04-04T00:00:00",
+            :start_at => "2011-03-28T00:00:00+01:00",
+            :end_at => "2011-04-04T00:00:00+01:00",
             :value => {
               :visits => 700,
               :site => "directgov"
@@ -33,8 +33,8 @@ describe "WeeklyVisitsRecorder" do
     item = WeeklyReach::Model.first
     item.metric.should == "visits"
     item.value.should == 700
-    item.start_at.should == DateTime.new(2011, 3, 28)
-    item.end_at.should == DateTime.new(2011, 4, 4)
+    item.start_at.should == DateTime.parse("2011-03-28T00:00:00+01:00")
+    item.end_at.should == DateTime.parse("2011-04-04T00:00:00+01:00")
     item.site.should == "directgov"
   end
 
@@ -46,8 +46,8 @@ describe "WeeklyVisitsRecorder" do
     item = WeeklyReach::Model.first
     item.metric.should == "visits"
     item.value.should == 700
-    item.start_at.should == DateTime.new(2011, 3, 28)
-    item.end_at.should == DateTime.new(2011, 4, 4)
+    item.start_at.should == DateTime.parse("2011-03-28T00:00:00+01:00")
+    item.end_at.should == DateTime.parse("2011-04-04T00:00:00+01:00")
     item.site.should == "govuk"
   end
 

--- a/spec/weekly_visits_model_spec.rb
+++ b/spec/weekly_visits_model_spec.rb
@@ -34,7 +34,7 @@ describe "WeeklyVisits" do
 
       records.should have(1).item
 
-      records.first.collected_at.should == DateTime.new(2012, 12, 12)
+      records.first.collected_at.should == DateTime.parse("2012-12-12T00:00:00+00:00")
       records.first.source.should == "Google Analytics"
       records.first.start_at.should == DateTime.parse("2011-03-28T00:00+01:00")
       records.first.end_at.should == DateTime.parse("2011-04-04T00:00:00+01:00")
@@ -51,7 +51,7 @@ describe "WeeklyVisits" do
 
       records.should have(1).item
 
-      records.first.collected_at.should == DateTime.new(2012, 12, 12)
+      records.first.collected_at.should == DateTime.parse("2012-12-12T00:00:00+00:00")
       records.first.source.should == "Google Analytics"
       records.first.start_at.should == DateTime.parse("2011-03-28T00:00+01:00")
       records.first.end_at.should == DateTime.parse("2011-04-04T00:00:00+01:00")
@@ -66,8 +66,8 @@ describe "WeeklyVisits" do
       WeeklyReach::Model.create(
           :value => 100,
           :metric => "visits",
-          :start_at => DateTime.new(2012, 12, 23), # Sunday
-          :end_at => DateTime.new(2012, 12, 30), # Sunday + 7 days
+          :start_at => DateTime.parse("2012-12-23T00:00:00+00:00"), # Sunday
+          :end_at => DateTime.parse("2012-12-30T00:00:00+00:00"), # Sunday + 7 days
           :collected_at => DateTime.now,
           :site => "govuk",
           :source => "Google Analytics"
@@ -76,8 +76,8 @@ describe "WeeklyVisits" do
       WeeklyReach::Model.create(
           :value => 400,
           :metric => "visits",
-          :start_at => DateTime.new(2011, 1, 23), # Sunday 24 months ago
-          :end_at => DateTime.new(2011, 1, 30), # (Sunday 24 months ago) + 7 days
+          :start_at => DateTime.parse("2011-01-23T00:00:00+00:00"), # Sunday 24 months ago
+          :end_at => DateTime.parse("2011-01-30T00:00:00+00:00"), # (Sunday 24 months ago) + 7 days
           :collected_at => DateTime.now,
           :site => "govuk",
           :source => "Google Analytics"
@@ -86,14 +86,14 @@ describe "WeeklyVisits" do
       WeeklyReach::Model.create(
           :value => 200,
           :metric => "visits",
-          :start_at => DateTime.new(2011, 7, 3), # Sunday 18 months ago
-          :end_at => DateTime.new(2011, 7, 10), # Sunday 18 months ago + 7 days
+          :start_at => DateTime.parse("2011-07-03T00:00:00+01:00"), # Sunday 18 months ago
+          :end_at => DateTime.parse("2011-07-10T00:00:00+01:00"), # Sunday 18 months ago + 7 days
           :collected_at => DateTime.now,
           :site => "govuk",
           :source => "Google Analytics"
       )
 
-      Timecop.travel(DateTime.new(2013, 1, 5)) do
+      Timecop.travel(DateTime.parse("2013-01-05T00:00:00+00:00")) do
         data = WeeklyReach::Model.last_18_months_data(:visits)
         data.length.should == 2
         data.first[:start_at].should == Date.new(2011, 7, 3)
@@ -109,8 +109,8 @@ describe "WeeklyVisits" do
       WeeklyReach::Model.create(
           :value => 100,
           :metric => "visits",
-          :start_at => DateTime.new(2012, 12, 24), # Monday
-          :end_at => DateTime.new(2012, 12, 31), # Monday + 7 days
+          :start_at => DateTime.parse("2012-12-24T00:00:00+00:00"), # Monday
+          :end_at => DateTime.parse("2012-12-31T00:00:00+00:00"), # Monday + 7 days
           :collected_at => DateTime.now,
           :site => "businesslink",
           :source => "Google Analytics"
@@ -119,8 +119,8 @@ describe "WeeklyVisits" do
       WeeklyReach::Model.create(
           :value => 400,
           :metric => "visits",
-          :start_at => DateTime.new(2011, 1, 23), # Sunday 24 months ago
-          :end_at => DateTime.new(2011, 1, 30), # (Sunday 24 months ago) + 7 days
+          :start_at => DateTime.parse("2011-01-23T00:00:00+00:00"), # Sunday 24 months ago
+          :end_at => DateTime.parse("2011-01-30T00:00:00+00:00"), # (Sunday 24 months ago) + 7 days
           :collected_at => DateTime.now,
           :site => "govuk",
           :source => "Google Analytics"
@@ -129,14 +129,14 @@ describe "WeeklyVisits" do
       WeeklyReach::Model.create(
           :value => 200,
           :metric => "visits",
-          :start_at => DateTime.new(2011, 7, 3), # Sunday 18 months ago
-          :end_at => DateTime.new(2011, 7, 10), # Sunday 18 months ago + 7 days
+          :start_at => DateTime.parse("2011-07-3T00:00:00+01:00"), # Sunday 18 months ago
+          :end_at => DateTime.parse("2011-07-10T00:00:00+01:00"), # Sunday 18 months ago + 7 days
           :collected_at => DateTime.now,
           :site => "govuk",
           :source => "Google Analytics"
       )
 
-      Timecop.travel(DateTime.new(2013, 1, 5)) do      
+      Timecop.travel(DateTime.parse("2013-01-05T00:00:00+00:00")) do
         data = WeeklyReach::Model.last_18_months_data(:visits)
         data.length.should == 2
         data.first[:value][:govuk].should == 200
@@ -148,8 +148,8 @@ describe "WeeklyVisits" do
   describe "validates start and end at" do
     it "should be valid data if data is ok" do
       model = FactoryGirl.create(:model, {
-          :start_at => DateTime.parse("2012-08-12T00:00:00"),
-          :end_at => DateTime.parse("2012-08-19T00:00:00"),
+          :start_at => DateTime.parse("2012-08-12T00:00:00+01:00"),
+          :end_at => DateTime.parse("2012-08-19T00:00:00+01:00"),
       })
 
       model.should be_valid
@@ -157,8 +157,8 @@ describe "WeeklyVisits" do
 
     it "should not be valid if there are 6 days between start at and end at" do
       model = FactoryGirl.create(:model, {
-          :start_at => DateTime.parse("2012-08-12T00:00:00"),
-          :end_at => DateTime.parse("2012-08-18T00:00:00"),
+          :start_at => DateTime.parse("2012-08-12T00:00:00+01:00"),
+          :end_at => DateTime.parse("2012-08-18T00:00:00+01:00"),
       })
 
       model.should_not be_valid
@@ -166,8 +166,8 @@ describe "WeeklyVisits" do
 
     it "should not be valid if there are 8 days between start at and end at" do
       model = FactoryGirl.create(:model, {
-          :start_at => DateTime.parse("2012-08-12T00:00:00"),
-          :end_at => DateTime.parse("2012-08-20T00:00:00"),
+          :start_at => DateTime.parse("2012-08-12T00:00:00+01:00"),
+          :end_at => DateTime.parse("2012-08-20T00:00:00+01:00"),
       })
 
       model.should_not be_valid

--- a/spec/weekly_visits_model_spec.rb
+++ b/spec/weekly_visits_model_spec.rb
@@ -17,8 +17,8 @@ describe "WeeklyVisits" do
               :_routing_key => "google_analytics.visits.weekly"
           },
           :payload => {
-              :start_at => "2011-03-28T00:00:00",
-              :end_at => "2011-04-04T00:00:00",
+              :start_at => "2011-03-28T00:00:00+01:00",
+              :end_at => "2011-04-04T00:00:00+01:00",
               :value => {
                 :visits => 700,
                 :site => "directgov"
@@ -36,8 +36,8 @@ describe "WeeklyVisits" do
 
       records.first.collected_at.should == DateTime.new(2012, 12, 12)
       records.first.source.should == "Google Analytics"
-      records.first.start_at.should == DateTime.new(2011, 3, 28)
-      records.first.end_at.should == DateTime.new(2011, 4, 4)
+      records.first.start_at.should == DateTime.parse("2011-03-28T00:00+01:00")
+      records.first.end_at.should == DateTime.parse("2011-04-04T00:00:00+01:00")
       records.first.site.should == "directgov"
       records.first.value.should == 700
     end
@@ -53,8 +53,8 @@ describe "WeeklyVisits" do
 
       records.first.collected_at.should == DateTime.new(2012, 12, 12)
       records.first.source.should == "Google Analytics"
-      records.first.start_at.should == DateTime.new(2011, 3, 28)
-      records.first.end_at.should == DateTime.new(2011, 4, 4)
+      records.first.start_at.should == DateTime.parse("2011-03-28T00:00+01:00")
+      records.first.end_at.should == DateTime.parse("2011-04-04T00:00:00+01:00")
       records.first.site.should == "directgov"
       records.first.value.should == 800
     end


### PR DESCRIPTION
- Integrate the daylight saving support provided by datainsight_recorder v0.4.1
- Add more info to error logging on save failure
- Be explicit about datetime offsets in tests (Zen of Python FTW)
